### PR TITLE
Fix overflow when displaying unrecruited heroes

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -78,7 +78,7 @@ typedef struct squad {
 
 typedef struct hero {
     bool active;
-    char name[16];
+    char name[20];
     int hp, hp_max;
     int ap, ap_max;
     int str, dex, mind;


### PR DESCRIPTION
The string "(Rk{enter} to hire)" occupies 20 bytes but the hero name buffer only has length of 16. The remaining 4 bytes overwrite the padding bytes and part of `hp` field which is unused in this path so it's harmless but with gcc source fortification enabled it is detected as buffer overflow. This can be easily reproduced by compiling with the fortification which additionally prints the relevant warning:

```
$ make CFLAGS="-D_FORTIFY_SOURCE=3 -O3"
In function ‘strcpy’,
    inlined from ‘ui_heroes’ at src/main.c:502:21,
    inlined from ‘main’ at src/main.c:755:17:
/usr/include/bits/string_fortified.h:81:10: warning: ‘__builtin___memcpy_chk’ writing 20 bytes into a region of size 16 overflows the destination [-Wstringop-overflow=]
```

Fixes: https://github.com/skeeto/goblin-com/issues/3